### PR TITLE
Fixed spelling of the word mandatory in .conf.js files

### DIFF
--- a/config/wdio.android.app.conf.js
+++ b/config/wdio.android.app.conf.js
@@ -24,7 +24,7 @@ config.capabilities = [
         'appium:deviceName': 'Pixel_8.1',
         'appium:platformVersion': '8.1',
         'appium:orientation': 'PORTRAIT',
-        // `automationName` will be manatory, see
+        // `automationName` will be mandatory, see
         // https://github.com/appium/appium/releases/tag/v1.13.0
         'appium:automationName': 'UiAutomator2',
         // The path to the app

--- a/config/wdio.android.browser.conf.js
+++ b/config/wdio.android.browser.conf.js
@@ -24,7 +24,7 @@ config.capabilities = [
         'appium:deviceName': 'Pixel_8.1',
         'appium:platformVersion': '8.1',
         'appium:orientation': 'PORTRAIT',
-        // `automationName` will be manatory, see
+        // `automationName` will be mandatory, see
         // https://github.com/appium/appium/releases/tag/v1.13.0
         'appium:automationName': 'UiAutomator2',
         'appium:newCommandTimeout': 240,

--- a/config/wdio.ios.app.conf.js
+++ b/config/wdio.ios.app.conf.js
@@ -24,7 +24,7 @@ config.capabilities = [
         'appium:deviceName': 'iPhone X',
         'appium:platformVersion': '12.2',
         'appium:orientation': 'PORTRAIT',
-        // `automationName` will be manatory, see
+        // `automationName` will be mandatory, see
         // https://github.com/appium/appium/releases/tag/v1.13.0
         'appium:automationName': 'XCUITest',
         // The path to the app

--- a/config/wdio.ios.browser.conf.js
+++ b/config/wdio.ios.browser.conf.js
@@ -24,7 +24,7 @@ config.capabilities = [
         'appium:deviceName': 'iPhone X',
         'appium:platformVersion': '12.2',
         'appium:orientation': 'PORTRAIT',
-        // `automationName` will be manatory, see
+        // `automationName` will be mandatory, see
         // https://github.com/appium/appium/releases/tag/v1.13.0
         'appium:automationName': 'XCUITest',
         'appium:newCommandTimeout': 240,


### PR DESCRIPTION
The word mandatory was misspelt as manatory. This PR fixes the spelling to mandatory.