### PR TITLE
Add localhost into wdio.shared.local.appium.conf

### DIFF
--- a/config/wdio.shared.local.appium.conf.ts
+++ b/config/wdio.shared.local.appium.conf.ts
@@ -15,6 +15,7 @@ config.services = (config.services ? config.services : []).concat([
                 // This is needed to tell Appium that we can execute local ADB commands
                 // and to automatically download the latest version of ChromeDriver
                 relaxedSecurity: true,
+                address: "localhost"
             },
         },
 


### PR DESCRIPTION
Currently, Appium refuses the execution and does not recognize its server address. Explicit the address capability to default server address fixes the problem.

#123 