### PR TITLE
tests: check if browser.hidKeyboard exist

### DIFF
--- a/tests/pageobjects/form.page.ts
+++ b/tests/pageobjects/form.page.ts
@@ -16,7 +16,9 @@ class FormPage extends Page {
     async login ({ username, password }: {username:string; password: string;}) {
         await this.username.setValue(username);
         await this.password.setValue(password);
-        await browser.hideKeyboard();
+        if (browser.hideKeyboard) {
+            await browser.hideKeyboard();
+        }
         await this.submitButton.click();
     }
 

--- a/tests/pageobjects/form.page.ts
+++ b/tests/pageobjects/form.page.ts
@@ -16,6 +16,7 @@ class FormPage extends Page {
     async login ({ username, password }: {username:string; password: string;}) {
         await this.username.setValue(username);
         await this.password.setValue(password);
+        // Mobile is only for mobile, if you test on a desktop browser it won't exist.
         if (browser.hideKeyboard) {
             await browser.hideKeyboard();
         }

--- a/tests/pageobjects/form.page.ts
+++ b/tests/pageobjects/form.page.ts
@@ -16,7 +16,7 @@ class FormPage extends Page {
     async login ({ username, password }: {username:string; password: string;}) {
         await this.username.setValue(username);
         await this.password.setValue(password);
-        // Mobile is only for mobile, if you test on a desktop browser it won't exist.
+        // only for mobile, if you test on a desktop browser `hideKeyboard` won't exist.
         if (browser.hideKeyboard) {
             await browser.hideKeyboard();
         }


### PR DESCRIPTION
Useful for non mobile browser.

This complete the addition of github action to demonstrate webdriver also works in non mobile web browser  https://github.com/webdriverio/appium-boilerplate/pull/138

Otherwise, tests will fail with error:

```bash
[chrome 90.0.4430.212 linux #0-2] Running: chrome (v90.0.4430.212) on linux
[chrome 90.0.4430.212 linux #0-2] Session ID: 0ee3af3c01e2449eb0b9f5e567daadab
[chrome 90.0.4430.212 linux #0-2]
[chrome 90.0.4430.212 linux #0-2] » /e2e/tests/wdio-demo/tests/specs/browser.form.spec.ts
[chrome 90.0.4430.212 linux #0-2] auth form
[chrome 90.0.4430.212 linux #0-2]    ✖ should deny access with wrong creds
[chrome 90.0.4430.212 linux #0-2]    ✖ should allow access with correct creds
[chrome 90.0.4430.212 linux #0-2]
[chrome 90.0.4430.212 linux #0-2] 2 failing (4s)
[chrome 90.0.4430.212 linux #0-2]
[chrome 90.0.4430.212 linux #0-2] 1) auth form should deny access with wrong creds
[chrome 90.0.4430.212 linux #0-2] browser.hideKeyboard is not a function
[chrome 90.0.4430.212 linux #0-2] TypeError: browser.hideKeyboard is not a function
[chrome 90.0.4430.212 linux #0-2]     at FormPage.login (/home/dka/workspace/github.com/pass-culture/pass-culture-app-native/e2e/tests/wdio-demo/tests/pageobjects/form.page.ts:27:20)
[chrome 90.0.4430.212 linux #0-2]     at processTicksAndRejections (node:internal/process/task_queues:95:5)
[chrome 90.0.4430.212 linux #0-2]     at async Context.<anonymous> (/home/dka/workspace/github.com/pass-culture/pass-culture-app-native/e2e/tests/wdio-demo/tests/specs/browser.form.spec.ts:6:9)
[chrome 90.0.4430.212 linux #0-2]
[chrome 90.0.4430.212 linux #0-2] 2) auth form should allow access with correct creds
[chrome 90.0.4430.212 linux #0-2] browser.hideKeyboard is not a function
[chrome 90.0.4430.212 linux #0-2] TypeError: browser.hideKeyboard is not a function
[chrome 90.0.4430.212 linux #0-2]     at FormPage.login (/home/dka/workspace/github.com/pass-culture/pass-culture-app-native/e2e/tests/wdio-demo/tests/pageobjects/form.page.ts:27:20)
[chrome 90.0.4430.212 linux #0-2]     at processTicksAndRejections (node:internal/process/task_queues:95:5)
[chrome 90.0.4430.212 linux #0-2]     at async Context.<anonymous> (/home/dka/workspace/github.com/pass-culture/pass-culture-app-native/e2e/tests/wdio-demo/tests/specs/browser.form.spec.ts:13:9)

```