### PR TITLE
test: fix driver.getContexts typing error

### DIFF
--- a/tests/helpers/WebView.ts
+++ b/tests/helpers/WebView.ts
@@ -1,4 +1,4 @@
-import { Context } from '@wdio/protocols/build/types'
+import { Context } from '@wdio/protocols'
 
 export const CONTEXT_REF = {
     NATIVE: 'native',

--- a/tests/helpers/WebView.ts
+++ b/tests/helpers/WebView.ts
@@ -1,3 +1,5 @@
+import { Context } from '@wdio/protocols/build/types'
+
 export const CONTEXT_REF = {
     NATIVE: 'native',
     WEBVIEW: 'webview',
@@ -45,13 +47,13 @@ class WebView {
     async switchToContext (context:string) {
         // The first context will always be the NATIVE_APP,
         // the second one will always be the WebdriverIO web page
-        await driver.switchContext((await this.getCurrentContexts())[context === CONTEXT_REF.NATIVE ? 0 : 1]);
+        await driver.switchContext(String(await this.getCurrentContexts())[context === CONTEXT_REF.NATIVE ? 0 : 1]);
     }
 
     /**
      * Returns an object with the list of all available contexts
      */
-    async getCurrentContexts ():Promise<string[]> {
+    async getCurrentContexts ():Promise<Context[]> {
         return driver.getContexts();
     }
 


### PR DESCRIPTION
`driver.getContexts()` does return an array of Context and not an array of String

I couldn't test it as webview already doesn't work (See #138 and #140)


```
$ tsc -p e2e/tsconfig.json
e2e/tests/wdio-demo/tests/helpers/WebView.ts:55:9 - error TS2322: Type 'Context[]' is not assignable to type 'string[]'.
  Type 'Context' is not assignable to type 'string'.
    Type 'DetailedContext' is not assignable to type 'string'.

55         return driver.getContexts();
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```