### PR TITLE
chore(devx): allow ts to recognize "driver"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
             "@wdio/mocha-framework",
             "expect-webdriverio",
             "@wdio/sauce-service",
+            "@wdio/globals/types"
         ]
     },
     "include": [


### PR DESCRIPTION
so that the TS compiler correctly recognizes code such as
```ts
expect(await driver.execute("flutter:checkHealth")).toEqual("ok")
```
w/o complaining "cannot find name 'driver'"